### PR TITLE
Fix compatibility with php-ai-client v0.3.x

### DIFF
--- a/includes/Provider/OllamaProvider.php
+++ b/includes/Provider/OllamaProvider.php
@@ -12,7 +12,6 @@ use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
 use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
-use WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 
@@ -68,9 +67,8 @@ class OllamaProvider extends AbstractApiProvider {
 		return new ProviderMetadata(
 			'ollama',
 			'Ollama',
-			ProviderTypeEnum::cloud(),
-			'https://ollama.com/settings/keys',
-			RequestAuthenticationMethod::apiKey()
+			ProviderTypeEnum::server(),
+			null
 		);
 	}
 


### PR DESCRIPTION
## Summary
This PR fixes the compatibility issue with `wordpress/php-ai-client` v0.3.x used by the WordPress AI Experiments plugin.

## Problem
The plugin currently uses the deprecated `RequestAuthenticationMethod` enum which was removed in php-ai-client v0.3.x, causing a fatal error:
```
PHP Fatal error: Class "WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod" not found
```

## Changes
- ✅ Removed deprecated `RequestAuthenticationMethod` enum import
- ✅ Updated `ProviderMetadata` constructor to match v0.3.x API (4 parameters instead of 5)
- ✅ Changed provider type from `cloud()` to `server()` (more accurate for Ollama's local architecture)
- ✅ Changed credentials URL to `null` (Ollama doesn't require API keys for local instances)

## Testing
After applying these changes, the plugin successfully registers with the WordPress AI infrastructure without errors.

**Before:**
```php
return new ProviderMetadata(
    'ollama',
    'Ollama',
    ProviderTypeEnum::cloud(),
    'https://ollama.com/settings/keys',
    RequestAuthenticationMethod::apiKey()  // ❌ Removed in v0.3.x
);
```

**After:**
```php
return new ProviderMetadata(
    'ollama',
    'Ollama',
    ProviderTypeEnum::server(),  // ✅ More accurate
    null  // ✅ No API key needed
);
```

## Compatibility
- ✅ Compatible with php-ai-client v0.3.x
- ✅ Compatible with WordPress AI Experiments 0.3.1
- ✅ Compatible with WordPress 6.9.1
- ✅ PHP 7.4+ (no breaking changes)

Closes #9

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FFueled%2Fai-provider-for-ollama%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-10-707d6ae7dd87a4e758187db279a481e6d3514d9a.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->