### PR TITLE
Test updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,11 +172,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '8.4', '8.3', '8.2', '8.1', '8.0', '7.4' ]
-        wp: [ latest, trunk ]
+        wp: [ trunk ]
         coverage: [ false ]
         include:
           - php: '8.4'
-            wp: latest
+            wp: trunk
             coverage: true
     env:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/trunk/wp-env.json",
-  "core": null,
+  "core": "WordPress/WordPress#master",
   "plugins": [ "." ],
   "env": {
     "development": {


### PR DESCRIPTION
### Description of the Change

This plugin has been built for WP 7.0+ only so right now some tests are failing because they are running on WP 6.9. We could just ignore those until 7.0 is released but it's also nice to see tests green across the board. So this PR removes the running of tests on WP 6.9 and only runs on 7.0. We can change this back once 7.0 is released.

In addition, makes an update to our test workflow to run on merges to `develop` and `main` instead of `develop` and `trunk` as this repo uses `main` as the main branch.

### How to test the Change

Ensure tests pass

### Changelog Entry

n/a

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/fueled/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FFueled%2Fai-provider-for-ollama%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-14-6906d6cfe8ff675e42717feb187815d6a066bd36.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->