### PR TITLE
Update menu name

### DIFF
--- a/includes/Settings/OllamaSettings.php
+++ b/includes/Settings/OllamaSettings.php
@@ -89,7 +89,7 @@ class OllamaSettings {
 	public function register_settings_screen(): void {
 		add_options_page(
 			__( 'Ollama Settings', 'ai-provider-for-ollama' ),
-			__( 'Ollama Settings', 'ai-provider-for-ollama' ),
+			__( 'Ollama', 'ai-provider-for-ollama' ),
 			'manage_options',
 			self::PAGE_SLUG,
 			array( $this, 'render_screen' )


### PR DESCRIPTION
### Description of the Change

Updates menu name from `Ollama Settings` to just `Ollama` since it's already nested under `Settings`.

Closes #18 

### How to test the Change

Ensure the menu shows correctly

<img width="181" height="377" alt="WordPress menu settings showing the Ollama menu" src="https://github.com/user-attachments/assets/a663d4e2-9df8-4d5f-8c49-7a78d0e8ba51" />

### Changelog Entry

> Changed - Update menu name from `Ollama Settings` to `Ollama`

### Credits

Props @jeffpaul, @dkotter 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/fueled/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FFueled%2Fai-provider-for-ollama%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-19-86f2fb42023ca127c69261686d1a40389381de03.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->