### PR TITLE
Undo plugin name change

### DIFF
--- a/.github/workflows/wporg-plugin-deploy.yml
+++ b/.github/workflows/wporg-plugin-deploy.yml
@@ -50,7 +50,6 @@ jobs:
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SLUG: fueled-ai-provider-for-ollama
 
     - name: Upload release asset
       uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0

--- a/plugin.php
+++ b/plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name:       Fueled AI Provider for Ollama
+ * Plugin Name:       AI Provider for Ollama
  * Plugin URI:        https://github.com/fueled/ai-provider-for-ollama
  * Description:       Ollama provider for the WordPress AI Client.
  * Requires at least: 7.0

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Fueled AI Provider for Ollama ===
+=== AI Provider for Ollama ===
 Contributors:      fueled, 10up
 Tags:              ai, ollama, llm, local-ai, connector
 Requires at least: 7.0

--- a/tests/e2e/specs/admin/activate.spec.js
+++ b/tests/e2e/specs/admin/activate.spec.js
@@ -11,9 +11,7 @@ const { visitAdminPage } = require( '../../utils/helpers' );
 test.describe( 'Plugin activation', () => {
 	test( 'Can deactivate the plugin', async ( { admin, page } ) => {
 		await visitAdminPage( admin, 'plugins.php' );
-		await page
-			.locator( '#deactivate-fueled-ai-provider-for-ollama' )
-			.click();
+		await page.locator( '#deactivate-ai-provider-for-ollama' ).click();
 		await expect( page.getByText( 'Plugin deactivated.' ) ).toHaveCount(
 			1
 		);
@@ -21,7 +19,7 @@ test.describe( 'Plugin activation', () => {
 
 	test( 'Can activate the plugin', async ( { admin, page } ) => {
 		await visitAdminPage( admin, 'plugins.php' );
-		await page.locator( '#activate-fueled-ai-provider-for-ollama' ).click();
+		await page.locator( '#activate-ai-provider-for-ollama' ).click();
 		await expect( page.getByText( 'Plugin activated.' ) ).toHaveCount( 1 );
 	} );
 
@@ -35,7 +33,7 @@ test.describe( 'Plugin activation', () => {
 		// Ensure the Settings link is visible.
 		await expect(
 			page.locator(
-				'tr[data-slug="fueled-ai-provider-for-ollama"] .row-actions a',
+				'tr[data-slug="ai-provider-for-ollama"] .row-actions a',
 				{
 					hasText: 'Settings',
 				}


### PR DESCRIPTION
### Description of the Change

This undoes the changes made in #22 as it seems the Plugin Review team is now fine with the way it was

### How to test the Change

Ensure the plugin name shows properly in the admin

### Changelog Entry

Not sure we need to call this out

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/fueled/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FFueled%2Fai-provider-for-ollama%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-25-1fa784199d8d8b1012dd54355a655827066df2de.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->