### PR TITLE
Ensure the `vendor` directory isn't excluded from our final release asset

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -3,8 +3,8 @@
 /.github
 /.wordpress-org
 /node_modules
+/src
 /tests
-/vendor
 
 # Files
 .*
@@ -22,4 +22,5 @@ phpstan.neon.dist
 phpunit.xml.dist
 README.md
 SECURITY.md
+tsconfig.json
 webpack.config.js

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,8 +6,8 @@
 /.github export-ignore
 /.wordpress-org export-ignore
 /node_modules export-ignore
+/src export-ignore
 /tests export-ignore
-/vendor export-ignore
 
 # Files
 /.* export-ignore


### PR DESCRIPTION
### Description of the Change

We have a report that the plugin on .org isn't working as expected and shows the following error:

`Your installation of the Ollama Provider plugin is incomplete. Please run composer install`

This message shows if the composer autoloader isn't found. In looking at the files that are in the SVN .org repo, I don't see the `vendor` directory. Looking into that, it seems we accidentally excluded that from our final release :(

This PR fixes that by ensuring the `vendor` directory isn't excluded and then excludes the `src` directory and the `tsconfig.json` file, as neither of those are needed in the final release.

### How to test the Change

Hard to test until we do an actual release

### Changelog Entry

> Fixed - Ensure the `vendor` directory ends up in our final release

### Credits

Props @soderlind, @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/fueled/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FFueled%2Fai-provider-for-ollama%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-31-0aa86c5a1abbeda3a5ea4647184d0b7481331739.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->