### PR TITLE
Integrate with the new `wpai_has_ai_credentials` filter

### DIFF
--- a/includes/Settings/OllamaSettings.php
+++ b/includes/Settings/OllamaSettings.php
@@ -8,8 +8,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use WordPress\AiClient\AiClient;
 use WP_Error;
+use WordPress\AiClient\AiClient;
 
 /**
  * Class for the Ollama settings in the WordPress admin.
@@ -285,13 +285,7 @@ class OllamaSettings {
 	 * @return bool True if the Ollama provider is connected, false otherwise.
 	 */
 	public function is_connected(): bool {
-		$models = $this->get_models();
-
-		if ( is_wp_error( $models ) ) {
-			return false;
-		}
-
-		return true;
+		return ! is_wp_error( $this->get_models() );
 	}
 
 	/**
@@ -299,7 +293,7 @@ class OllamaSettings {
 	 *
 	 * @since x.x.x
 	 *
-	 * @return WP_Error|array<string, ModelMetadata> The models.
+	 * @return \WP_Error|array<string, \Fueled\AiProviderForOllama\Settings\ModelMetadata> The models.
 	 */
 	public function get_models() {
 		$provider_id = 'ollama';
@@ -320,9 +314,7 @@ class OllamaSettings {
 
 			// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$model_metadata_directory = $provider_classname::modelMetadataDirectory();
-			$model_metadata_objects   = $model_metadata_directory->listModelMetadata();
-
-			return $model_metadata_objects;
+			return $model_metadata_directory->listModelMetadata();
 		} catch ( \Throwable $e ) {
 			/* translators: %s: Error message. */
 			return new WP_Error( 'could_not_list_models', sprintf( __( 'Could not list models for provider - are the API credentials invalid? Error: %s', 'ai-provider-for-ollama' ), $e->getMessage() ), 500 );

--- a/includes/Settings/OllamaSettings.php
+++ b/includes/Settings/OllamaSettings.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use WordPress\AiClient\AiClient;
+use WP_Error;
 
 /**
  * Class for the Ollama settings in the WordPress admin.
@@ -37,6 +38,7 @@ class OllamaSettings {
 		add_action( 'admin_menu', array( $this, 'register_settings_screen' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_settings_script' ) );
 		add_action( 'wp_ajax_' . self::AJAX_ACTION, array( $this, 'ajax_list_models' ) );
+		add_filter( 'wpai_has_ai_credentials', array( $this, 'is_connected' ) );
 	}
 
 	/**
@@ -266,11 +268,45 @@ class OllamaSettings {
 			wp_send_json_error( __( 'Insufficient permissions.', 'ai-provider-for-ollama' ), 403 );
 		}
 
+		$models = $this->get_models();
+
+		if ( is_wp_error( $models ) ) {
+			wp_send_json_error( $models->get_error_message(), $models->get_error_code() );
+		}
+
+		wp_send_json_success( $models );
+	}
+
+	/**
+	 * Checks if the Ollama provider is connected.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool True if the Ollama provider is connected, false otherwise.
+	 */
+	public function is_connected(): bool {
+		$models = $this->get_models();
+
+		if ( is_wp_error( $models ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Gets the models from the Ollama provider.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return WP_Error|array<string, ModelMetadata> The models.
+	 */
+	public function get_models() {
 		$provider_id = 'ollama';
 		$registry    = AiClient::defaultRegistry();
 
 		if ( ! $registry->hasProvider( $provider_id ) ) {
-			wp_send_json_error( __( 'AI provider not found.', 'ai-provider-for-ollama' ), 404 );
+			return new WP_Error( 'ai_provider_not_found', __( 'AI provider not found.', 'ai-provider-for-ollama' ), 404 );
 		}
 
 		$provider_classname = $registry->getProviderClassName( $provider_id );
@@ -279,17 +315,17 @@ class OllamaSettings {
 			// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$provider_availability = $provider_classname::availability();
 			if ( ! $provider_availability->isConfigured() ) {
-				wp_send_json_error( __( 'AI provider not configured - missing API credentials.', 'ai-provider-for-ollama' ), 400 );
+				return new WP_Error( 'ai_provider_not_configured', __( 'AI provider not configured - missing API credentials.', 'ai-provider-for-ollama' ), 400 );
 			}
 
 			// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$model_metadata_directory = $provider_classname::modelMetadataDirectory();
 			$model_metadata_objects   = $model_metadata_directory->listModelMetadata();
 
-			wp_send_json_success( $model_metadata_objects );
+			return $model_metadata_objects;
 		} catch ( \Throwable $e ) {
 			/* translators: %s: Error message. */
-			wp_send_json_error( sprintf( __( 'Could not list models for provider - are the API credentials invalid? Error: %s', 'ai-provider-for-ollama' ), $e->getMessage() ), 500 );
+			return new WP_Error( 'could_not_list_models', sprintf( __( 'Could not list models for provider - are the API credentials invalid? Error: %s', 'ai-provider-for-ollama' ), $e->getMessage() ), 500 );
 		}
 	}
 

--- a/includes/Settings/OllamaSettings.php
+++ b/includes/Settings/OllamaSettings.php
@@ -309,7 +309,7 @@ class OllamaSettings {
 			// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			$provider_availability = $provider_classname::availability();
 			if ( ! $provider_availability->isConfigured() ) {
-				return new WP_Error( 'ai_provider_not_configured', __( 'AI provider not configured - missing API credentials.', 'ai-provider-for-ollama' ), 400 );
+				return new WP_Error( 'ai_provider_not_configured', __( 'AI provider not configured - ensure Ollama is running or you have valid API credentials.', 'ai-provider-for-ollama' ), 400 );
 			}
 
 			// phpcs:ignore Generic.Commenting.DocComment.MissingShort
@@ -317,7 +317,7 @@ class OllamaSettings {
 			return $model_metadata_directory->listModelMetadata();
 		} catch ( \Throwable $e ) {
 			/* translators: %s: Error message. */
-			return new WP_Error( 'could_not_list_models', sprintf( __( 'Could not list models for provider - are the API credentials invalid? Error: %s', 'ai-provider-for-ollama' ), $e->getMessage() ), 500 );
+			return new WP_Error( 'could_not_list_models', sprintf( __( 'Could not list models for provider - is Ollama running or are the API credentials invalid? Error: %s', 'ai-provider-for-ollama' ), $e->getMessage() ), 500 );
 		}
 	}
 

--- a/tests/Integration/Settings/OllamaSettingsTest.php
+++ b/tests/Integration/Settings/OllamaSettingsTest.php
@@ -5,6 +5,17 @@ declare( strict_types=1 );
 namespace Fueled\AiProviderForOllama\Tests\Integration\Settings;
 
 use Fueled\AiProviderForOllama\Settings\OllamaSettings;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
+use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
+use WordPress\AiClient\Providers\Contracts\ProviderInterface;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 
 /**
  * Tests for OllamaSettings.
@@ -22,7 +33,55 @@ class OllamaSettingsTest extends \WP_UnitTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
+		$this->reset_registry();
+		$this->reset_mock_provider_state();
 		$this->settings = new OllamaSettings();
+	}
+
+	protected function tearDown(): void {
+		$this->reset_registry();
+		$this->reset_mock_provider_state();
+		parent::tearDown();
+	}
+
+	/**
+	 * Resets the AiClient default registry so each test starts clean.
+	 */
+	private function reset_registry(): void {
+		$ai_client_reflection = new \ReflectionClass( AiClient::class );
+		$registry_prop        = $ai_client_reflection->getProperty( 'defaultRegistry' );
+		$registry_prop->setAccessible( true );
+		$registry_prop->setValue( null, null );
+	}
+
+	/**
+	 * Resets all mutable static state used by mock provider test doubles.
+	 */
+	private function reset_mock_provider_state(): void {
+		MockOllamaProviderAvailability::$is_configured = true;
+		MockOllamaModelMetadataDirectory::$throw_on_list = false;
+		MockOllamaModelMetadataDirectory::$models        = array();
+	}
+
+	/**
+	 * Registers the mock ollama provider in the default registry.
+	 */
+	private function register_mock_provider(): void {
+		AiClient::defaultRegistry()->registerProvider( MockOllamaProvider::class );
+	}
+
+	/**
+	 * Creates test model metadata for mock model directory responses.
+	 *
+	 * @param string $id Model identifier.
+	 */
+	private function create_mock_model_metadata( string $id = 'llama3.1' ): ModelMetadata {
+		return new ModelMetadata(
+			$id,
+			'Ollama Test Model',
+			array( CapabilityEnum::textGeneration() ),
+			array()
+		);
 	}
 
 	// -----------------------------------------------------------------------
@@ -118,5 +177,227 @@ class OllamaSettingsTest extends \WP_UnitTestCase {
 				array( $this->settings, 'ajax_list_models' )
 			)
 		);
+	}
+
+	/**
+	 * Tests that init() registers is_connected on wpai_has_ai_credentials.
+	 */
+	public function test_init_registers_wpai_has_ai_credentials_filter(): void {
+		$this->settings->init();
+		$this->assertNotFalse(
+			has_filter( 'wpai_has_ai_credentials', array( $this->settings, 'is_connected' ) )
+		);
+	}
+
+	/**
+	 * Tests that get_models() returns an error if the provider is not registered.
+	 */
+	public function test_get_models_returns_error_when_provider_is_not_registered(): void {
+		$result = $this->settings->get_models();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ai_provider_not_found', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data() );
+	}
+
+	/**
+	 * Tests that get_models() returns an error if provider availability is unconfigured.
+	 */
+	public function test_get_models_returns_error_when_provider_is_not_configured(): void {
+		MockOllamaProviderAvailability::$is_configured = false;
+		$this->register_mock_provider();
+
+		$result = $this->settings->get_models();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ai_provider_not_configured', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data() );
+	}
+
+	/**
+	 * Tests that get_models() returns listed models when provider is configured.
+	 */
+	public function test_get_models_returns_models_when_provider_is_configured(): void {
+		$this->register_mock_provider();
+		$model = $this->create_mock_model_metadata();
+		MockOllamaModelMetadataDirectory::$models = array( $model );
+
+		$result = $this->settings->get_models();
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertInstanceOf( ModelMetadata::class, $result[0] );
+		$this->assertSame( $model->getId(), $result[0]->getId() );
+	}
+
+	/**
+	 * Tests that get_models() returns an error when model listing throws.
+	 */
+	public function test_get_models_returns_error_when_model_listing_throws(): void {
+		$this->register_mock_provider();
+		MockOllamaModelMetadataDirectory::$throw_on_list = true;
+
+		$result = $this->settings->get_models();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'could_not_list_models', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data() );
+		$this->assertStringContainsString( 'Could not list models for provider', $result->get_error_message() );
+	}
+
+	/**
+	 * Tests that is_connected() returns false when model lookup errors.
+	 */
+	public function test_is_connected_returns_false_when_get_models_fails(): void {
+		$this->assertFalse( $this->settings->is_connected() );
+	}
+
+	/**
+	 * Tests that is_connected() returns true when model lookup succeeds.
+	 */
+	public function test_is_connected_returns_true_when_get_models_succeeds(): void {
+		$this->register_mock_provider();
+		MockOllamaModelMetadataDirectory::$models = array( $this->create_mock_model_metadata() );
+
+		$this->assertTrue( $this->settings->is_connected() );
+	}
+
+	/**
+	 * Tests that wpai_has_ai_credentials filter resolves to false when disconnected.
+	 */
+	public function test_wpai_has_ai_credentials_filter_returns_false_when_disconnected(): void {
+		$this->settings->init();
+
+		$result = apply_filters( 'wpai_has_ai_credentials', true );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that wpai_has_ai_credentials filter resolves to true when connected.
+	 */
+	public function test_wpai_has_ai_credentials_filter_returns_true_when_connected(): void {
+		$this->settings->init();
+		$this->register_mock_provider();
+		MockOllamaModelMetadataDirectory::$models = array( $this->create_mock_model_metadata() );
+
+		$result = apply_filters( 'wpai_has_ai_credentials', false );
+
+		$this->assertTrue( $result );
+	}
+}
+
+/**
+ * Mock provider for testing OllamaSettings::get_models() behavior.
+ */
+class MockOllamaProvider implements ProviderInterface {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function metadata(): ProviderMetadata {
+		return new ProviderMetadata(
+			'ollama',
+			'Mock Ollama',
+			ProviderTypeEnum::server()
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function model( string $model_id, ?ModelConfig $model_config = null ): ModelInterface {
+		throw new InvalidArgumentException( 'Model loading is not used in this test.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function availability(): ProviderAvailabilityInterface {
+		return new MockOllamaProviderAvailability();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function modelMetadataDirectory(): ModelMetadataDirectoryInterface {
+		return new MockOllamaModelMetadataDirectory();
+	}
+}
+
+/**
+ * Mock provider availability used by MockOllamaProvider.
+ */
+class MockOllamaProviderAvailability implements ProviderAvailabilityInterface {
+
+	/**
+	 * Whether the provider should report as configured.
+	 *
+	 * @var bool
+	 */
+	public static bool $is_configured = true;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isConfigured(): bool {
+		return self::$is_configured;
+	}
+}
+
+/**
+ * Mock model metadata directory used by MockOllamaProvider.
+ */
+class MockOllamaModelMetadataDirectory implements ModelMetadataDirectoryInterface {
+
+	/**
+	 * Whether listModelMetadata should throw.
+	 *
+	 * @var bool
+	 */
+	public static bool $throw_on_list = false;
+
+	/**
+	 * Models to return when listing model metadata.
+	 *
+	 * @var array<int, ModelMetadata>
+	 */
+	public static array $models = array();
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function listModelMetadata(): array {
+		if ( self::$throw_on_list ) {
+			throw new \RuntimeException( 'Mock listing error.' );
+		}
+
+		return self::$models;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function hasModelMetadata( string $model_id ): bool {
+		foreach ( self::$models as $model_metadata ) {
+			if ( $model_metadata->getId() === $model_id ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getModelMetadata( string $model_id ): ModelMetadata {
+		foreach ( self::$models as $model_metadata ) {
+			if ( $model_metadata->getId() === $model_id ) {
+				return $model_metadata;
+			}
+		}
+
+		throw new InvalidArgumentException( 'Model metadata not found.' );
 	}
 }

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -24,7 +24,7 @@ test.describe( 'Plugin settings', () => {
 		// Ensure an error message is displayed.
 		await expect(
 			page.locator( '#ollama-model-status', {
-				hasText: 'Could not connect to load models.',
+				hasText: 'AI provider not configured',
 			} )
 		).toHaveCount( 1 );
 	} );


### PR DESCRIPTION
### Description of the Change

The AI plugin doesn't see the Ollama Connector as being connected since it doesn't require an API key. A new `wpai_has_ai_credentials` filter was introduced in that plugin that allows individual Connectors to override this behavior.

This PR hooks into that filter and if we have models available, we assume Ollama is connected and return true.

### How to test the Change

1. Check out this PR
2. Install the AI plugin
3. Ensure Ollama is running and go to the AI settings page
4. Ensure no error message is shown
5. Turn off Ollama and refresh the settings page
6. An error should now show

### Changelog Entry

> Added - Ensure the AI plugin sees Ollama as a valid, connected provider

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/fueled/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FFueled%2Fai-provider-for-ollama%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-43-c440c4517f8a62da09a2cbab70f68b6e4e0a94d0.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->