### PR TITLE
Ensure we properly support structured outputs

### DIFF
--- a/includes/Models/OllamaImageGenerationModel.php
+++ b/includes/Models/OllamaImageGenerationModel.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 
 namespace Fueled\AiProviderForOllama\Models;
 
+use Fueled\AiProviderForOllama\Models\Traits\OllamaRequestOptionsTrait;
 use Fueled\AiProviderForOllama\Provider\OllamaProvider;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Files\DTO\File;
@@ -47,6 +48,7 @@ use WordPress\AiClient\Results\Enums\FinishReasonEnum;
  * }
  */
 class OllamaImageGenerationModel extends AbstractApiBasedModel implements ImageGenerationModelInterface {
+	use OllamaRequestOptionsTrait;
 
 	/**
 	 * Generates images from a prompt using the Ollama API.
@@ -95,33 +97,7 @@ class OllamaImageGenerationModel extends AbstractApiBasedModel implements ImageG
 	 * @return \WordPress\AiClient\Providers\Http\DTO\RequestOptions Prepared request options.
 	 */
 	private function prepareRequestOptionsForImageGeneration(): RequestOptions {
-		$existing_options = $this->getRequestOptions();
-		if ( null !== $existing_options ) {
-			$request_options = RequestOptions::fromArray( $existing_options->toArray() );
-		} else {
-			$request_options = new RequestOptions();
-		}
-
-		$custom_options = $this->getConfig()->getCustomOptions();
-
-		$request_timeout = 300.0;
-		if ( isset( $custom_options['ollama.request_timeout'] ) && is_numeric( $custom_options['ollama.request_timeout'] ) ) {
-			$request_timeout = (float) $custom_options['ollama.request_timeout'];
-		}
-
-		$connect_timeout = 10.0;
-		if ( isset( $custom_options['ollama.connect_timeout'] ) && is_numeric( $custom_options['ollama.connect_timeout'] ) ) {
-			$connect_timeout = (float) $custom_options['ollama.connect_timeout'];
-		}
-
-		// Always enforce request timeout for image generation to avoid 90s defaults.
-		$request_options->setTimeout( $request_timeout );
-
-		if ( null === $request_options->getConnectTimeout() ) {
-			$request_options->setConnectTimeout( $connect_timeout );
-		}
-
-		return $request_options;
+		return $this->prepareRequestOptions( 300.0, 10.0 );
 	}
 
 	/**

--- a/includes/Models/OllamaTextGenerationModel.php
+++ b/includes/Models/OllamaTextGenerationModel.php
@@ -4,8 +4,10 @@ declare( strict_types=1 );
 
 namespace Fueled\AiProviderForOllama\Models;
 
+use Fueled\AiProviderForOllama\Models\Traits\OllamaRequestOptionsTrait;
 use Fueled\AiProviderForOllama\Provider\OllamaProvider;
 use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
 use WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCompatibleTextGenerationModel;
 
@@ -17,6 +19,7 @@ use WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCo
  * @since 1.0.0
  */
 class OllamaTextGenerationModel extends AbstractOpenAiCompatibleTextGenerationModel {
+	use OllamaRequestOptionsTrait;
 
 	/**
 	 * Prepares the response format parameter for Ollama's OpenAI-compatible API.
@@ -56,6 +59,13 @@ class OllamaTextGenerationModel extends AbstractOpenAiCompatibleTextGenerationMo
 		array $headers = array(),
 		$data = null
 	): Request {
+		$request_options = $this->prepareRequestOptionsForTextGeneration();
+
+		// Keep transport-only timeout options out of the OpenAI-compatible payload.
+		if ( is_array( $data ) ) {
+			unset( $data['ollama.request_timeout'], $data['ollama.connect_timeout'] );
+		}
+
 		// Ollama supports OpenAI-compatible endpoints at /v1/.
 		$path = ltrim( (string) preg_replace( '#^v1/?#', '', ltrim( $path, '/' ) ), '/' );
 		$path = '/v1/' . $path;
@@ -65,7 +75,22 @@ class OllamaTextGenerationModel extends AbstractOpenAiCompatibleTextGenerationMo
 			OllamaProvider::url( $path ),
 			$headers,
 			$data,
-			$this->getRequestOptions()
+			$request_options
 		);
+	}
+
+	/**
+	 * Prepares request options for text generation with a longer default timeout.
+	 *
+	 * Supported custom options:
+	 *  - ollama.request_timeout (seconds)
+	 *  - ollama.connect_timeout (seconds)
+	 *
+	 * @since x.x.x
+	 *
+	 * @return \WordPress\AiClient\Providers\Http\DTO\RequestOptions Prepared request options.
+	 */
+	private function prepareRequestOptionsForTextGeneration(): RequestOptions {
+		return $this->prepareRequestOptions( 60.0, 10.0 );
 	}
 }

--- a/includes/Models/OllamaTextGenerationModel.php
+++ b/includes/Models/OllamaTextGenerationModel.php
@@ -19,6 +19,33 @@ use WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCo
 class OllamaTextGenerationModel extends AbstractOpenAiCompatibleTextGenerationModel {
 
 	/**
+	 * Prepares the response format parameter for Ollama's OpenAI-compatible API.
+	 *
+	 * Ollama's OpenAI-compatible API uses the same response_format key as OpenAI,
+	 * but schema mode expects the schema to be nested at json_schema.schema.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<string, mixed>|null $output_schema The output schema.
+	 * @return array<string, mixed> The prepared response format parameter.
+	 */
+	protected function prepareResponseFormatParam( ?array $output_schema ): array {
+		if ( is_array( $output_schema ) ) {
+			return array(
+				'type'        => 'json_schema',
+				'json_schema' => array(
+					'name'   => 'response_schema',
+					'schema' => $output_schema,
+				),
+			);
+		}
+
+		return array(
+			'type' => 'json_object',
+		);
+	}
+
+	/**
 	 * {@inheritDoc}
 	 *
 	 * @since 1.0.0

--- a/includes/Models/Traits/OllamaRequestOptionsTrait.php
+++ b/includes/Models/Traits/OllamaRequestOptionsTrait.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Shared Ollama request options preparation.
+ *
+ * @package Fueled\AiProviderForOllama\Models\Traits
+ * @since   x.x.x
+ */
+
+declare( strict_types=1 );
+
+namespace Fueled\AiProviderForOllama\Models\Traits;
+
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+
+/**
+ * Trait for preparing request options with configurable timeout defaults.
+ *
+ * @since x.x.x
+ */
+trait OllamaRequestOptionsTrait {
+
+	/**
+	 * Prepares request options with timeout defaults and custom overrides.
+	 *
+	 * Supported custom options:
+	 *  - ollama.request_timeout (seconds)
+	 *  - ollama.connect_timeout (seconds)
+	 *
+	 * @since x.x.x
+	 *
+	 * @param float $default_request_timeout Default request timeout in seconds.
+	 * @param float $default_connect_timeout Default connect timeout in seconds.
+	 * @return \WordPress\AiClient\Providers\Http\DTO\RequestOptions Prepared request options.
+	 */
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	protected function prepareRequestOptions(
+		float $default_request_timeout,
+		float $default_connect_timeout
+	): RequestOptions {
+		$existing_options = $this->getRequestOptions();
+		if ( null !== $existing_options ) {
+			$request_options = RequestOptions::fromArray( $existing_options->toArray() );
+		} else {
+			$request_options = new RequestOptions();
+		}
+
+		$custom_options = $this->getConfig()->getCustomOptions();
+
+		$request_timeout = $default_request_timeout;
+		if ( isset( $custom_options['ollama.request_timeout'] ) && is_numeric( $custom_options['ollama.request_timeout'] ) ) {
+			$request_timeout = (float) $custom_options['ollama.request_timeout'];
+		}
+
+		$connect_timeout = $default_connect_timeout;
+		if ( isset( $custom_options['ollama.connect_timeout'] ) && is_numeric( $custom_options['ollama.connect_timeout'] ) ) {
+			$connect_timeout = (float) $custom_options['ollama.connect_timeout'];
+		}
+
+		$request_options->setTimeout( $request_timeout );
+
+		if ( null === $request_options->getConnectTimeout() ) {
+			$request_options->setConnectTimeout( $connect_timeout );
+		}
+
+		return $request_options;
+	}
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -31,6 +31,7 @@ parameters:
 			- includes/Metadata/OllamaModelMetadataDirectory.php
 			- includes/Models/OllamaImageGenerationModel.php
 			- includes/Models/OllamaTextGenerationModel.php
+			- includes/Models/Traits/OllamaRequestOptionsTrait.php
 			- includes/Provider/OllamaProvider.php
 			- includes/Settings/OllamaSettings.php
 		analyseAndScan:

--- a/tests/Integration/Models/MockOllamaTextGenerationModel.php
+++ b/tests/Integration/Models/MockOllamaTextGenerationModel.php
@@ -30,4 +30,14 @@ class MockOllamaTextGenerationModel extends OllamaTextGenerationModel {
 	): Request {
 		return $this->createRequest( $method, $path, $headers, $data );
 	}
+
+	/**
+	 * Publicly exposes the protected prepareResponseFormatParam() method.
+	 *
+	 * @param array<string, mixed>|null $output_schema The output schema.
+	 * @return array<string, mixed> The prepared response format parameter.
+	 */
+	public function expose_prepare_response_format_param( ?array $output_schema ): array {
+		return $this->prepareResponseFormatParam( $output_schema );
+	}
 }

--- a/tests/Integration/Models/OllamaTextGenerationModelTest.php
+++ b/tests/Integration/Models/OllamaTextGenerationModelTest.php
@@ -13,11 +13,7 @@ use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 
 /**
- * Tests for OllamaTextGenerationModel path normalization in createRequest().
- *
- * All tests exercise the path-normalisation logic that is the only custom
- * behaviour in OllamaTextGenerationModel — everything else is covered by
- * the php-ai-client AbstractOpenAiCompatibleTextGenerationModel tests.
+ * Tests for OllamaTextGenerationModel request behavior.
  *
  * @covers \Fueled\AiProviderForOllama\Models\OllamaTextGenerationModel
  */
@@ -93,5 +89,45 @@ class OllamaTextGenerationModelTest extends TestCase {
 			'chat/completions'
 		);
 		$this->assertStringStartsWith( 'http://localhost:11434', $request->getUri() );
+	}
+
+	/**
+	 * Tests that JSON output without schema uses json_object response format.
+	 */
+	public function test_prepare_response_format_uses_json_object_without_schema(): void {
+		$response_format = $this->model->expose_prepare_response_format_param( null );
+
+		$this->assertSame(
+			array(
+				'type' => 'json_object',
+			),
+			$response_format
+		);
+	}
+
+	/**
+	 * Tests that JSON schema output is nested at json_schema.schema.
+	 */
+	public function test_prepare_response_format_wraps_schema_for_ollama_openai_compat(): void {
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'name' => array( 'type' => 'string' ),
+			),
+			'required'   => array( 'name' ),
+		);
+
+		$response_format = $this->model->expose_prepare_response_format_param( $schema );
+
+		$this->assertSame(
+			array(
+				'type'        => 'json_schema',
+				'json_schema' => array(
+					'name'   => 'response_schema',
+					'schema' => $schema,
+				),
+			),
+			$response_format
+		);
 	}
 }

--- a/tests/Integration/Models/OllamaTextGenerationModelTest.php
+++ b/tests/Integration/Models/OllamaTextGenerationModelTest.php
@@ -9,7 +9,9 @@ use PHPUnit\Framework\TestCase;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
 use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
 use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 
 /**
@@ -129,5 +131,90 @@ class OllamaTextGenerationModelTest extends TestCase {
 			),
 			$response_format
 		);
+	}
+
+	/**
+	 * Tests that text requests use longer default request/connect timeouts.
+	 */
+	public function test_default_request_timeouts_are_applied_to_text_requests(): void {
+		$request = $this->model->expose_create_request(
+			HttpMethodEnum::POST(),
+			'chat/completions',
+			array(),
+			array()
+		);
+
+		$this->assertNotNull( $request->getOptions() );
+		$this->assertSame( 60.0, $request->getOptions()->getTimeout() );
+		$this->assertSame( 10.0, $request->getOptions()->getConnectTimeout() );
+	}
+
+	/**
+	 * Tests that custom timeout options are applied and removed from payload data.
+	 */
+	public function test_custom_timeouts_are_applied_and_not_sent_in_payload(): void {
+		$this->model->setConfig(
+			ModelConfig::fromArray(
+				array(
+					'customOptions' => array(
+						'ollama.request_timeout' => 45,
+						'ollama.connect_timeout' => 2,
+					),
+				)
+			)
+		);
+
+		$request = $this->model->expose_create_request(
+			HttpMethodEnum::POST(),
+			'chat/completions',
+			array(),
+			array(
+				'ollama.request_timeout' => 45,
+				'ollama.connect_timeout' => 2,
+				'model'                  => 'llama3.2',
+			)
+		);
+
+		$this->assertNotNull( $request->getOptions() );
+		$this->assertSame( 45.0, $request->getOptions()->getTimeout() );
+		$this->assertSame( 2.0, $request->getOptions()->getConnectTimeout() );
+		$this->assertSame(
+			array(
+				'model' => 'llama3.2',
+			),
+			$request->getData()
+		);
+	}
+
+	/**
+	 * Tests that an existing connect timeout is preserved for text requests.
+	 */
+	public function test_existing_connect_timeout_is_preserved_for_text_requests(): void {
+		$request_options = new RequestOptions();
+		$request_options->setConnectTimeout( 6.0 );
+		$request_options->setTimeout( 20.0 );
+		$this->model->setRequestOptions( $request_options );
+
+		$this->model->setConfig(
+			ModelConfig::fromArray(
+				array(
+					'customOptions' => array(
+						'ollama.request_timeout' => 90,
+						'ollama.connect_timeout' => 2,
+					),
+				)
+			)
+		);
+
+		$request = $this->model->expose_create_request(
+			HttpMethodEnum::POST(),
+			'chat/completions',
+			array(),
+			array()
+		);
+
+		$this->assertNotNull( $request->getOptions() );
+		$this->assertSame( 90.0, $request->getOptions()->getTimeout() );
+		$this->assertSame( 6.0, $request->getOptions()->getConnectTimeout() );
 	}
 }


### PR DESCRIPTION
### Description of the Change

Ollama supports models that support structured outputs but we weren't properly parsing those ourselves. This means any API request that requested a structured output wouldn't work properly.

### How to test the Change

1. Pull this PR down and set up the Ollama provider
2. Install the [AI plugin](https://wordpress.org/plugins/ai/) and turn on Content Classification and Review Notes (both use structured outputs)
3. Test both and ensure they work, noting that depending on the model you're using, you may run into timeouts on Review Notes

### Changelog Entry

> Changed - Increase the standard timeout to be 60 seconds
> Fixed - Properly parse structured outputs

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/fueled/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FFueled%2Fai-provider-for-ollama%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-49-b91542eb12a520e60af0e88bf129ff23864bab30.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->