### PR TITLE
Show model capabilities next to the model name

### DIFF
--- a/includes/Settings/OllamaSettings.php
+++ b/includes/Settings/OllamaSettings.php
@@ -132,7 +132,7 @@ class OllamaSettings {
 		}
 		?>
 
-		<div class="wrap" style="max-width: 50rem;">
+		<div class="wrap ai-provider-for-ollama-settings-screen">
 			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 			<p>
 				<?php
@@ -246,6 +246,14 @@ class OllamaSettings {
 			$version,
 			true
 		);
+
+		wp_enqueue_style(
+			'ai-provider-for-ollama-settings',
+			plugins_url( 'build/admin/style-settings.css', $plugin_dir . 'plugin.php' ),
+			array(),
+			$version
+		);
+		wp_style_add_data( 'ai-provider-for-ollama-settings', 'rtl', 'replace' );
 
 		wp_localize_script(
 			'ai-provider-for-ollama-settings',

--- a/src/admin/settings/index.ts
+++ b/src/admin/settings/index.ts
@@ -22,14 +22,96 @@ interface AjaxResponse {
 interface ModelMetadata {
 	id: string;
 	name: string;
+	supportedCapabilities?: string[];
+	supportedOptions?: SupportedOption[];
+}
+
+interface SupportedOption {
+	name: string;
+	supportedValues?: unknown[];
 }
 
 const ERROR_COLOR = '#d63638';
 
+const CAPABILITY_LABELS: Record< string, string > = {
+	text_generation: __( 'Text generation', 'ai-provider-for-ollama' ),
+	image_generation: __( 'Image generation', 'ai-provider-for-ollama' ),
+	text_to_speech_conversion: __( 'Text-to-speech', 'ai-provider-for-ollama' ),
+	speech_generation: __( 'Speech generation', 'ai-provider-for-ollama' ),
+	music_generation: __( 'Music generation', 'ai-provider-for-ollama' ),
+	video_generation: __( 'Video generation', 'ai-provider-for-ollama' ),
+	embedding_generation: __(
+		'Embedding generation',
+		'ai-provider-for-ollama'
+	),
+	chat_history: __( 'Chat history', 'ai-provider-for-ollama' ),
+};
+
+/**
+ * Gets a display label for a capability value.
+ *
+ * @param {string} capability The raw capability value.
+ * @return {string} A translated label.
+ * @since x.x.x
+ */
+function getCapabilityLabel( capability: string ): string {
+	if ( CAPABILITY_LABELS[ capability ] ) {
+		return CAPABILITY_LABELS[ capability ];
+	}
+
+	return capability
+		.split( '_' )
+		.map( ( word ) => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
+		.join( ' ' );
+}
+
+/**
+ * Checks if model supports image input (vision).
+ *
+ * @param {ModelMetadata} model The model metadata.
+ * @return {boolean} Whether vision is supported.
+ * @since x.x.x
+ */
+function supportsVision( model: ModelMetadata ): boolean {
+	const inputModalities = model.supportedOptions?.find(
+		( option ) => option.name === 'inputModalities'
+	);
+	if (
+		! inputModalities ||
+		! Array.isArray( inputModalities.supportedValues )
+	) {
+		return false;
+	}
+
+	return inputModalities.supportedValues.some(
+		( modalitySet ) =>
+			Array.isArray( modalitySet ) && modalitySet.includes( 'image' )
+	);
+}
+
+/**
+ * Gets displayable capability labels for a model.
+ *
+ * @param {ModelMetadata} model The model metadata.
+ * @return {string[]} Capability labels to display.
+ * @since x.x.x
+ */
+function getModelCapabilityLabels( model: ModelMetadata ): string[] {
+	const labels = new Set(
+		( model.supportedCapabilities ?? [] ).map( getCapabilityLabel )
+	);
+
+	if ( supportsVision( model ) ) {
+		labels.add( __( 'Vision', 'ai-provider-for-ollama' ) );
+	}
+
+	return Array.from( labels );
+}
+
 /**
  * Loads and displays the available models in a list.
  *
- * @param config The configuration object.
+ * @param {Config} config The configuration object.
  * @since 1.0.0
  */
 async function loadModels( config: Config ): Promise< void > {
@@ -105,6 +187,14 @@ async function loadModels( config: Config ): Promise< void > {
 		const code = document.createElement( 'code' );
 		code.textContent = model.id;
 		item.appendChild( code );
+
+		const capabilityLabels = getModelCapabilityLabels( model );
+		if ( capabilityLabels.length > 0 ) {
+			const capabilities = document.createElement( 'span' );
+			capabilities.textContent = ` (${ capabilityLabels.join( ', ' ) })`;
+			item.appendChild( capabilities );
+		}
+
 		list.appendChild( item );
 	}
 	container.appendChild( list );

--- a/src/admin/settings/index.ts
+++ b/src/admin/settings/index.ts
@@ -4,6 +4,11 @@
 import apiFetch from '@wordpress/api-fetch';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 interface Config {
 	ajaxUrl: string;
 }
@@ -29,6 +34,11 @@ interface ModelMetadata {
 interface SupportedOption {
 	name: string;
 	supportedValues?: unknown[];
+}
+
+interface DisplayCapability {
+	key: string;
+	label: string;
 }
 
 const ERROR_COLOR = '#d63638';
@@ -74,7 +84,9 @@ function getCapabilityLabel( capability: string ): string {
  */
 function supportsVision( model: ModelMetadata ): boolean {
 	const inputModalities = model.supportedOptions?.find(
-		( option ) => option.name === 'inputModalities'
+		( option ) =>
+			option.name === 'inputModalities' ||
+			option.name === 'input_modalities'
 	);
 	if (
 		! inputModalities ||
@@ -90,22 +102,58 @@ function supportsVision( model: ModelMetadata ): boolean {
 }
 
 /**
- * Gets displayable capability labels for a model.
+ * Gets displayable capabilities for a model.
  *
  * @param {ModelMetadata} model The model metadata.
- * @return {string[]} Capability labels to display.
+ * @return {DisplayCapability[]} Capabilities to display.
  * @since x.x.x
  */
-function getModelCapabilityLabels( model: ModelMetadata ): string[] {
-	const labels = new Set(
-		( model.supportedCapabilities ?? [] ).map( getCapabilityLabel )
-	);
-
-	if ( supportsVision( model ) ) {
-		labels.add( __( 'Vision', 'ai-provider-for-ollama' ) );
+function getModelDisplayCapabilities(
+	model: ModelMetadata
+): DisplayCapability[] {
+	const capabilitiesMap = new Map< string, DisplayCapability >();
+	for ( const capabilityKey of model.supportedCapabilities ?? [] ) {
+		capabilitiesMap.set( capabilityKey, {
+			key: capabilityKey,
+			label: getCapabilityLabel( capabilityKey ),
+		} );
 	}
 
-	return Array.from( labels );
+	if ( supportsVision( model ) ) {
+		capabilitiesMap.set( 'vision', {
+			key: 'vision',
+			label: __( 'Vision', 'ai-provider-for-ollama' ),
+		} );
+	}
+
+	return Array.from( capabilitiesMap.values() );
+}
+
+/**
+ * Creates a visual pill for a model capability.
+ *
+ * @param {DisplayCapability} capability The displayable capability.
+ * @return {HTMLSpanElement} The capability pill element.
+ * @since x.x.x
+ */
+function createCapabilityPill(
+	capability: DisplayCapability
+): HTMLSpanElement {
+	const pill = document.createElement( 'span' );
+	pill.className = 'ai-provider-for-ollama-capability-pill';
+	pill.textContent = capability.label;
+
+	if ( capability.key === 'vision' ) {
+		pill.classList.add( 'ai-provider-for-ollama-capability-pill--vision' );
+	}
+
+	if ( capability.key === 'image_generation' ) {
+		pill.classList.add(
+			'ai-provider-for-ollama-capability-pill--image-generation'
+		);
+	}
+
+	return pill;
 }
 
 /**
@@ -182,16 +230,24 @@ async function loadModels( config: Config ): Promise< void > {
 	container.appendChild( count );
 
 	const list = document.createElement( 'ul' );
+	list.className = 'ai-provider-for-ollama-models-list';
+
 	for ( const model of models ) {
 		const item = document.createElement( 'li' );
+		item.className = 'ai-provider-for-ollama-model-item';
 		const code = document.createElement( 'code' );
 		code.textContent = model.id;
 		item.appendChild( code );
 
-		const capabilityLabels = getModelCapabilityLabels( model );
-		if ( capabilityLabels.length > 0 ) {
+		const displayCapabilities = getModelDisplayCapabilities( model );
+		if ( displayCapabilities.length > 0 ) {
 			const capabilities = document.createElement( 'span' );
-			capabilities.textContent = ` (${ capabilityLabels.join( ', ' ) })`;
+			capabilities.className = 'ai-provider-for-ollama-capabilities';
+
+			for ( const capability of displayCapabilities ) {
+				capabilities.appendChild( createCapabilityPill( capability ) );
+			}
+
 			item.appendChild( capabilities );
 		}
 

--- a/src/admin/settings/style.scss
+++ b/src/admin/settings/style.scss
@@ -1,0 +1,45 @@
+.ai-provider-for-ollama-settings-screen {
+	max-width: 50rem;
+}
+
+#ollama-models-container {
+	.ai-provider-for-ollama-models-list {
+		margin: 10px 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.ai-provider-for-ollama-model-item {
+		margin-bottom: 0.625rem;
+	}
+
+	.ai-provider-for-ollama-capabilities {
+		display: inline-flex;
+		flex-wrap: wrap;
+		gap: 0.375rem;
+		margin-left: 0.5rem;
+		vertical-align: middle;
+	}
+
+	.ai-provider-for-ollama-capability-pill {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.125rem 0.5rem;
+		border-radius: 999px;
+		background-color: #dbe3f0;
+		color: #1f2937;
+		font-size: 12px;
+		line-height: 1.5;
+		font-weight: 500;
+
+		&.ai-provider-for-ollama-capability-pill--vision {
+			background-color: #dbeafe;
+			color: #1e3a8a;
+		}
+
+		&.ai-provider-for-ollama-capability-pill--image-generation {
+			background-color: #ede9fe;
+			color: #4c1d95;
+		}
+	}
+}


### PR DESCRIPTION
### Description of the Change

On our settings screen, we output a list of all available models which is mostly just there to make it clear that you are properly connected and you do have models installed (you can't actually choose any specific model, this is just for display purposes).

As noted in #48, showing the capabilities of each model is helpful as it's not always clear just based on the name. This PR takes the capabilities that we determine based on the model information Ollama provides and we use that to add "pills" next to each model name that specify what that model can do (text generation, image generation, vision, etc).

Closes #48

<img width="858" height="554" alt="Model names and capabilities showing on the settings screen " src="https://github.com/user-attachments/assets/e71cd9f9-e128-4fe5-9bca-6eae011d32e1" />

### How to test the Change

1. Pull this PR down and run `npmi i && npm run build`
2. Ensure you have Ollama running and at least one model installed
3. Visit `Settings > Ollama` and ensure you see the installed models showing with their capabilities

### Changelog Entry

> Added - Show the capabilities of each model next to the model name on our settings page

### Credits

Props @jeffpaul, @dkotter 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/fueled/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FFueled%2Fai-provider-for-ollama%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-51-e9a394567abc5448667d34c1d1d2e9ac0842a810.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->