### PR TITLE
Integrate with the new `wpai_is_{$slug}_connector_configured` filter

### DIFF
--- a/includes/Settings/OllamaSettings.php
+++ b/includes/Settings/OllamaSettings.php
@@ -39,6 +39,7 @@ class OllamaSettings {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_settings_script' ) );
 		add_action( 'wp_ajax_' . self::AJAX_ACTION, array( $this, 'ajax_list_models' ) );
 		add_filter( 'wpai_has_ai_credentials', array( $this, 'is_connected' ) );
+		add_filter( 'wpai_is_ollama_connector_configured', array( $this, 'is_connected' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

The AI plugin doesn't see the Ollama Connector as being connected within the status dashboard widget since it doesn't require an API key. A new `wpai_is_{$slug}_connector_configured` filter is [being introduced](https://github.com/WordPress/ai/pull/473/) in that plugin that allows individual Connectors to override this behavior.

This PR hooks into that filter and if we have models available, we assume Ollama is connected and return true. This matches what we added in #43

Closes #54

### How to test the Change

1. Install the AI plugin from https://github.com/WordPress/ai/pull/473/
2. Pull this PR down
3. Go to the admin dashboard and ensure Ollama shows as connected in the status widget

### Changelog Entry

> Added - Ensure the AI plugin sees Ollama as a valid, connected provider within the status dashboard widget

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/fueled/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FFueled%2Fai-provider-for-ollama%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-55-c36a7aff4f45123cefbeddb70012d95f8d4e6b92.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->