### PR TITLE
Ensure our logo path includes the `plugins` directory

### DIFF
--- a/includes/Provider/OllamaProvider.php
+++ b/includes/Provider/OllamaProvider.php
@@ -96,7 +96,7 @@ class OllamaProvider extends AbstractApiProvider {
 		if ( version_compare( AiClient::VERSION, '1.3.0', '>=' ) ) {
 			$provider_meta[] = defined( 'AI_PROVIDER_FOR_OLLAMA_PLUGIN_DIR' )
 				? AI_PROVIDER_FOR_OLLAMA_PLUGIN_DIR . 'includes/Provider/logo.svg'
-				: __DIR__ . '/logo.svg';
+				: dirname( __DIR__, 2 ) . '/includes/Provider/logo.svg';
 		}
 
 		return new ProviderMetadata( ...$provider_meta );

--- a/includes/Provider/OllamaProvider.php
+++ b/includes/Provider/OllamaProvider.php
@@ -94,7 +94,9 @@ class OllamaProvider extends AbstractApiProvider {
 
 		// Provider logo path support was added in 1.3.0.
 		if ( version_compare( AiClient::VERSION, '1.3.0', '>=' ) ) {
-			$provider_meta[] = __DIR__ . '/logo.svg';
+			$provider_meta[] = defined( 'AI_PROVIDER_FOR_OLLAMA_PLUGIN_DIR' )
+				? AI_PROVIDER_FOR_OLLAMA_PLUGIN_DIR . 'includes/Provider/logo.svg'
+				: __DIR__ . '/logo.svg';
 		}
 
 		return new ProviderMetadata( ...$provider_meta );


### PR DESCRIPTION
### Description of the Change

As reported at https://wordpress.org/support/topic/notice-about-logo-url/, a PHP notice can show in certain circumstances due to WordPress not seeing our logo path as being in the `plugins` directory.

Note I've not been able to replicate this issue myself.

This PR updates to use the existing `AI_PROVIDER_FOR_OLLAMA_PLUGIN_DIR` constant, if it exists, which should always point to the correct directory. If that doesn't exist, it means someone has included the code directly as a composer dependency (and may not even be using WordPress) so we fallback to looking within the current directory.

### How to test the Change

Verify you still see a logo on the Connectors screen and don't see any PHP notices

### Changelog Entry

> Fixed - More robust path inclusion for the logo

### Credits

Props @ABCdatos, @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/fueled/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FFueled%2Fai-provider-for-ollama%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-61-fa5eeef0cb5af6f40a8c5b29f700661cbfa2c55e.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->